### PR TITLE
Agregando UI de seteo de preferencias a nivel de usuario

### DIFF
--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -8,21 +8,6 @@ import { UserInformationForm } from "../src/Components/UserInformationForm";
 import { me } from "../src/helpers/API";
 import { jsconfTheme, ViewportSizes } from "../styles/theme";
 
-const Title = styled.h2`
-  font-family: "Koulen";
-  font-style: normal;
-  font-weight: 400;
-  display: inline-block;
-  line-height: 1;
-  transition-duration: 250ms;
-  transition-property: font-size;
-  font-size: 2.5rem;
-
-  @media (min-width: ${ViewportSizes.TabletLandscape}px) {
-    font-size: 2.2rem;
-  }
-`;
-
 const StyledContainer = styled.div`
   width: 100%;
   max-width: 500px;
@@ -30,6 +15,13 @@ const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  padding-top: 4rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  @media (min-width: ${ViewportSizes.Phone}px) {
+    padding-left: 0rem;
+    padding-right: 0rem;
+  }
 `;
 
 const SytledImageContainer = styled.div`
@@ -59,7 +51,6 @@ const Settings = () => {
           para poder informarte los próximos pasos.
         </Alert>
       ) : null}
-      <Title>Configuracion</Title>
       {isLoading ? (
         <SytledImageContainer>
           <StyledLoadingImage />

--- a/src/Components/UserInformationForm/index.tsx
+++ b/src/Components/UserInformationForm/index.tsx
@@ -20,6 +20,10 @@ import {
 } from "../Form/schema";
 import { useQuery } from "@tanstack/react-query";
 import { transparentize } from "polished";
+import { H3, P } from "../core/Typography";
+import { Anchor } from "../CustomMarkdown";
+import Link from "next/link";
+import { AnimatePresence, motion } from "framer-motion";
 
 interface SelectOption {
   label: any;
@@ -40,17 +44,25 @@ interface FormData {
   seniority?: string;
   yearsOfExperience?: number;
   gender?: SelectOption;
+  foodPreference?: SelectOption;
+  shirtSize?: SelectOption;
+  shirtStyle?: SelectOption;
+  foodAllergy?: SelectOption;
+  pronouns?: SelectOption;
 }
 
 const LANGUAGE = "es";
 
 const InputC = styled.input<{ error: boolean }>`
-  padding: 8px 0px;
+  padding-bottom: 8px;
   display: flex;
   flex-direction: row;
   width: 100%;
   border: ${({ error }) => `0px solid ${error ? "#F45B69;" : "#F0E040"}`};
   border-bottom-width: 1px;
+  ::placeholder {
+    color: ${({ theme }) => transparentize(0.5, theme.colors.white)};
+  }
 `;
 
 const SytledImageContainer = styled.div`
@@ -78,7 +90,7 @@ const UpdateButton = styled(GenericBtn)`
   margin-left: auto;
 `;
 
-const ErrorMessage = styled.section<{ color?: string }>`
+const ErrorMessage = styled(motion.section)<{ color?: string }>`
   height: 20px;
   font-size: 16px;
   text-transform: capitalize;
@@ -86,9 +98,45 @@ const ErrorMessage = styled.section<{ color?: string }>`
   padding-bottom: 32px;
 `;
 
+const Form = styled.form`
+  display: flex;
+  gap: 2rem;
+  flex-direction: column;
+`;
+
+const FormSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const FormFieldsSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+const FormFieldSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+const FormLabel = styled.label`
+  cursor: pointer;
+`;
+
 const Error = (props: { message?: any; color?: string }) => {
   const { message, color } = props;
-  return <ErrorMessage color={color}>{message}</ErrorMessage>;
+  return (
+    <AnimatePresence mode="popLayout" initial={false}>
+      {message && (
+        <ErrorMessage color={color} {...animation}>
+          {message}
+        </ErrorMessage>
+      )}
+    </AnimatePresence>
+  );
 };
 
 const customStyles: StylesConfig = {
@@ -130,6 +178,10 @@ const customStyles: StylesConfig = {
       borderColor: jsconfTheme.colors.jsconfYellow,
     },
   }),
+  placeholder: ({ ...provided }) => ({
+    ...provided,
+    color: transparentize(0.5, jsconfTheme.colors.white),
+  }),
   singleValue: ({ ...provided }) => ({
     ...provided,
     background: "black",
@@ -155,32 +207,171 @@ const countryOptions = Object.entries(countryObj).map(
   }
 );
 
-export const UserInformationForm = () => {
-  const { data: user, refetch } = useQuery(["me"], me);
-  const countrySelectId = useId();
-  const genderSelectId = useId();
-  const [submitMessage, setSubmitMessage] = useState("");
-  const [formErrors, setFormErrors] = useState<string[]>([]);
-  const genderOptions = useMemo(() => {
+const uppercaseFirstLetter = (string: string) => {
+  return `${string[0].toUpperCase()}${string.slice(1)}`;
+};
+
+const useGetGenderOptions = (gender?: string | null) => {
+  return useMemo(() => {
     const defaultGenderValues = [
       { value: "male", label: "Masculino" },
       { value: "female", label: "Femenino" },
       { value: "other", label: "Otro" },
     ];
-    if (!user?.gender) {
+    if (!gender) {
       return defaultGenderValues;
     }
     const alreadyExists = defaultGenderValues.some(
-      ({ value }) => value === user?.gender
+      ({ value }) => value === gender
     );
     if (!alreadyExists) {
       defaultGenderValues.push({
-        value: user?.gender,
-        label: user?.gender,
+        value: gender.toLowerCase(),
+        label: uppercaseFirstLetter(gender),
       });
     }
     return defaultGenderValues;
-  }, [user?.gender]);
+  }, [gender]);
+};
+
+const useGetFoodPreferenceOptions = (foodPreference?: string | null) => {
+  return useMemo(() => {
+    const defaultFoodPreferenceOptions = [
+      {
+        value: "vegetariana",
+        label: "Vegetariana",
+      },
+      {
+        value: "vegana",
+        label: "Vegana",
+      },
+      {
+        value: "ninguna",
+        label: "Ninguna",
+      },
+    ];
+    if (!foodPreference) {
+      return defaultFoodPreferenceOptions;
+    }
+    const alreadyExists = defaultFoodPreferenceOptions.some(
+      ({ value }) => value === foodPreference
+    );
+    if (!alreadyExists) {
+      defaultFoodPreferenceOptions.push({
+        value: foodPreference.toLowerCase(),
+        label: uppercaseFirstLetter(foodPreference),
+      });
+    }
+    return defaultFoodPreferenceOptions;
+  }, [foodPreference]);
+};
+
+const useGetFoodAllergyOptions = (foodAllergy?: string | null) => {
+  return useMemo(() => {
+    const defaultFoodAllergyOptions = [
+      {
+        value: "nueces",
+        label: "Nueces (Maní, Almendras, etc)",
+      },
+      {
+        value: "crustaceos",
+        label: "Crustaceos",
+      },
+      {
+        value: "nueces",
+        label: "Ninguna",
+      },
+    ];
+    if (!foodAllergy) {
+      return defaultFoodAllergyOptions;
+    }
+    const alreadyExists = defaultFoodAllergyOptions.some(
+      ({ value }) => value === foodAllergy
+    );
+    if (!alreadyExists) {
+      defaultFoodAllergyOptions.push({
+        value: foodAllergy.toLowerCase(),
+        label: uppercaseFirstLetter(foodAllergy),
+      });
+    }
+    return defaultFoodAllergyOptions;
+  }, [foodAllergy]);
+};
+
+const useGetPronounsOptions = (pronouns?: string | null) => {
+  return useMemo(() => {
+    const defaultPronounsOptions = [
+      {
+        value: "ella",
+        label: "Ella",
+      },
+      {
+        value: "elle",
+        label: "Elle",
+      },
+      {
+        value: "el",
+        label: "El",
+      },
+    ];
+    if (!pronouns) {
+      return defaultPronounsOptions;
+    }
+    const alreadyExists = defaultPronounsOptions.some(
+      ({ value }) => value === pronouns
+    );
+    if (!alreadyExists) {
+      defaultPronounsOptions.push({
+        value: pronouns.toLowerCase(),
+        label: uppercaseFirstLetter(pronouns),
+      });
+    }
+    return defaultPronounsOptions;
+  }, [pronouns]);
+};
+const defaultShirtSizeOptions = [
+  { value: "XS", label: "XS" },
+  { value: "S", label: "S" },
+  { value: "M", label: "M" },
+  { value: "L", label: "L" },
+  { value: "XL", label: "XL" },
+  { value: "XXL", label: "XXL" },
+  { value: "XXXL", label: "XXXL" },
+];
+
+const defaultShirtStyleOptions = [
+  { value: "corte_ajustado", label: "Corte ajustado" },
+  { value: "corte_clasico", label: "Corte clásico" },
+];
+
+const animation = {
+  layout: "position" as "position",
+  initial: { opacity: 0, translateX: -50 },
+  animate: { opacity: 1, translateX: 0 },
+  exit: { opacity: 0, translateX: 50 },
+  transition: {
+    type: "spring",
+    damping: 25,
+  },
+};
+
+export const UserInformationForm = () => {
+  const { data: user, refetch } = useQuery(["me"], me);
+  const countrySelectId = useId();
+  const foodPreferenceId = useId();
+  const shirtSizeId = useId();
+  const shirtStyleId = useId();
+  const genderSelectId = useId();
+  const pronounsSelectId = useId();
+  const [submitMessage, setSubmitMessage] = useState("");
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const genderOptions = useGetGenderOptions(user?.gender);
+  const foodPreferenceOptions = useGetFoodPreferenceOptions(
+    user?.foodPreference
+  );
+  const foodAllergyOptions = useGetFoodAllergyOptions(user?.foodAllergy);
+  const pronounsOptions = useGetPronounsOptions(user?.pronouns);
+
   const defaultValues = useMemo(
     () => ({
       name: user?.name ?? "",
@@ -199,9 +390,39 @@ export const UserInformationForm = () => {
             (gender: SelectOption) => gender.value === user.gender
           )
         : undefined,
+      foodPreference: user?.foodPreference
+        ? foodPreferenceOptions.find(
+            (foodPreference: SelectOption) =>
+              foodPreference.value === user.foodPreference
+          )
+        : undefined,
+      shirtSize: user?.shirtSize
+        ? defaultShirtSizeOptions.find(
+            (defaultShirtSize) => defaultShirtSize.value === user.shirtSize
+          )
+        : undefined,
+      shirtStyle: user?.shirtStyle
+        ? defaultShirtStyleOptions.find(
+            (defaultShirtStyle) => defaultShirtStyle.value === user.shirtStyle
+          )
+        : undefined,
+      foodAllergy: user?.foodAllergy
+        ? foodAllergyOptions.find(
+            (foodAllergy: SelectOption) =>
+              foodAllergy.value === user.foodAllergy
+          )
+        : undefined,
+      pronouns: user?.pronouns
+        ? pronounsOptions.find(
+            (pronouns: SelectOption) => pronouns.value === user.pronouns
+          )
+        : undefined,
     }),
     [
       genderOptions,
+      foodPreferenceOptions,
+      foodAllergyOptions,
+      pronounsOptions,
       user?.company,
       user?.country,
       user?.gender,
@@ -210,6 +431,11 @@ export const UserInformationForm = () => {
       user?.seniority,
       user?.username,
       user?.yearsOfExperience,
+      user?.pronouns,
+      user?.foodAllergy,
+      user?.foodPreference,
+      user?.shirtSize,
+      user?.shirtStyle,
     ]
   );
   const {
@@ -259,6 +485,22 @@ export const UserInformationForm = () => {
             yearsOfExperience: data?.yearsOfExperience,
           }
         : {}),
+      ...(touchedFields?.foodPreference &&
+      data?.foodPreference !== user?.foodPreference
+        ? { foodPreference: data?.foodPreference?.value }
+        : {}),
+      ...(touchedFields?.shirtSize && data?.shirtSize !== user?.shirtSize
+        ? { shirtSize: data?.shirtSize?.value }
+        : {}),
+      ...(touchedFields?.shirtStyle && data?.shirtStyle !== user?.shirtStyle
+        ? { shirtStyle: data?.shirtStyle?.value }
+        : {}),
+      ...(touchedFields?.foodAllergy && data?.foodAllergy !== user?.foodAllergy
+        ? { foodAllergy: data?.foodAllergy?.value }
+        : {}),
+      ...(touchedFields?.pronouns && data?.pronouns !== user?.pronouns
+        ? { pronouns: data?.pronouns?.value }
+        : {}),
     };
 
     setSubmitMessage("");
@@ -282,7 +524,7 @@ export const UserInformationForm = () => {
   });
 
   return (
-    <form
+    <Form
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onSubmit={onSubmit}
     >
@@ -297,100 +539,253 @@ export const UserInformationForm = () => {
           <StyledLoadingImage />
         )}
       </SytledImageContainer>
-      <InputC
-        {...register("name", nameValidation)}
-        placeholder="Nombre"
-        error={Boolean(errors.name?.type)}
-      />
-      <Error {...errors.name} />
+      <FormSection>
+        <H3>INFORMACIÓN PERSONAL</H3>
+        <FormFieldsSection>
+          <FormFieldSection>
+            <FormLabel htmlFor="name">Nombre</FormLabel>
+            <InputC
+              {...register("name", nameValidation)}
+              id="name"
+              placeholder="Nombre"
+              error={Boolean(errors.name?.type)}
+            />
+            <Error {...errors.name} />
+          </FormFieldSection>
 
-      <InputC
-        {...register("username", nameValidation)}
-        placeholder="Nombre de Usuario"
-        error={Boolean(errors.username?.type)}
-      />
-      <Error {...errors.username} />
+          <FormFieldSection>
+            <FormLabel htmlFor="username">Nombre de Usuario</FormLabel>
+            <InputC
+              {...register("username", nameValidation)}
+              id="username"
+              placeholder="Nombre de Usuario"
+              inputMode="email"
+              error={Boolean(errors.username?.type)}
+            />
+            <Error {...errors.username} />
+          </FormFieldSection>
 
-      {!user?.email ? (
-        <>
-          <InputC
-            {...register("email", emailValidation)}
-            placeholder="Correo Electrónico"
-            error={Boolean(errors.email?.type)}
-          />
-          <Error {...errors.email} />
-        </>
-      ) : null}
+          {!user?.email ? (
+            <>
+              <FormFieldSection>
+                <FormLabel htmlFor="email">Correo Electrónico</FormLabel>
+                <InputC
+                  {...register("email", emailValidation)}
+                  id="email"
+                  placeholder="Correo Electrónico"
+                  inputMode="email"
+                  error={Boolean(errors.email?.type)}
+                />
+                <Error {...errors.email} />
+              </FormFieldSection>
+            </>
+          ) : null}
 
-      <Controller
-        name="country"
-        control={control}
-        render={({ field }) => (
-          <Select
-            {...field}
-            isClearable
-            placeholder="Seleccionar País"
-            styles={customStyles}
-            options={countryOptions}
-            instanceId={countrySelectId}
-          />
-        )}
-      />
-      <Error {...errors.country} />
+          <FormFieldSection>
+            <FormLabel>País</FormLabel>
+            <Controller
+              name="country"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  isClearable
+                  placeholder="Seleccionar País"
+                  styles={customStyles}
+                  options={countryOptions}
+                  instanceId={countrySelectId}
+                />
+              )}
+            />
+            <Error {...errors.country} />
+          </FormFieldSection>
 
-      <InputC
-        {...register("company", optionalStringValidation)}
-        placeholder="Compañía"
-        error={Boolean(errors.company?.type)}
-      />
-      <Error {...errors.company} />
+          <FormFieldSection>
+            <FormLabel htmlFor="company">Compañía</FormLabel>
+            <InputC
+              {...register("company", optionalStringValidation)}
+              id="company"
+              placeholder="Compañía"
+              error={Boolean(errors.company?.type)}
+            />
+            <Error {...errors.company} />
+          </FormFieldSection>
 
-      <InputC
-        {...register("position", optionalStringValidation)}
-        placeholder="Posición"
-        error={Boolean(errors.position?.type)}
-      />
-      <Error {...errors.position} />
+          <FormFieldSection>
+            <FormLabel htmlFor="position">Posición / Cargo</FormLabel>
+            <InputC
+              {...register("position", optionalStringValidation)}
+              id="position"
+              placeholder="Posición / Cargo"
+              error={Boolean(errors.position?.type)}
+            />
+            <Error {...errors.position} />
+          </FormFieldSection>
 
-      <InputC
-        {...register("seniority", optionalStringValidation)}
-        placeholder="Seniority"
-        error={Boolean(errors.seniority?.type)}
-      />
-      <Error {...errors.seniority} />
+          <FormFieldSection>
+            <FormLabel htmlFor="seniority">Seniority</FormLabel>
+            <InputC
+              {...register("seniority", optionalStringValidation)}
+              id="seniority"
+              placeholder="Seniority"
+              error={Boolean(errors.seniority?.type)}
+            />
+            <Error {...errors.seniority} />
+          </FormFieldSection>
 
-      <InputC
-        {...register("yearsOfExperience", notNegativeNumberValidation)}
-        placeholder="Años de Experiencia "
-        type="number"
-        min={0}
-        max={100}
-        error={Boolean(errors.yearsOfExperience?.type)}
-      />
-      <Error {...errors.yearsOfExperience} />
+          <FormFieldSection>
+            <FormLabel htmlFor="yearsOfExperience">
+              Años de Experiencia
+            </FormLabel>
+            <InputC
+              {...register("yearsOfExperience", notNegativeNumberValidation)}
+              id="yearsOfExperience"
+              placeholder="Años de Experiencia"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={100}
+              error={Boolean(errors.yearsOfExperience?.type)}
+            />
+            <Error {...errors.yearsOfExperience} />
+          </FormFieldSection>
 
-      <Controller
-        name="gender"
-        control={control}
-        render={({ field }) => (
-          <Select
-            {...field}
-            isClearable
-            placeholder="Seleccionar Género"
-            styles={customStyles}
-            options={genderOptions}
-            instanceId={genderSelectId}
-          />
-        )}
-      />
-      <Error {...errors.gender} />
+          <FormFieldSection>
+            <FormLabel>Género</FormLabel>
+            <Controller
+              name="gender"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  isClearable
+                  placeholder="Seleccionar Género"
+                  styles={customStyles}
+                  options={genderOptions}
+                  instanceId={genderSelectId}
+                />
+              )}
+            />
+            <Error {...errors.gender} />
+          </FormFieldSection>
+        </FormFieldsSection>
+      </FormSection>
 
-      <UpdateButton
-        type="submit"
-        disabled={Object.entries(errors).length > 0 || !isDirty}
-      >
-        Actualizar
-      </UpdateButton>
+      <FormSection>
+        <H3>Preferencias</H3>
+        <P>
+          Estas preferencias se asignarán por defecto a todos tus tickets,
+          puedes asignar preferencias específicas a cada ticket entrando a{" "}
+          <Link href="/mytickets" legacyBehavior>
+            <Anchor>/mytickets</Anchor>
+          </Link>
+        </P>
+        <FormFieldsSection>
+          <FormFieldSection>
+            <FormLabel>Tamaño de Polera</FormLabel>
+            <Controller
+              name="shirtSize"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  placeholder="Tamaño de Polera"
+                  isSearchable={false}
+                  styles={customStyles}
+                  options={defaultShirtSizeOptions}
+                  instanceId={shirtSizeId}
+                />
+              )}
+            />
+            <Error {...errors.country} />
+          </FormFieldSection>
+
+          <FormFieldSection>
+            <FormLabel>Estilo de Polera</FormLabel>
+            <Controller
+              name="shirtStyle"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  placeholder="Estilo de polera"
+                  isSearchable={false}
+                  styles={customStyles}
+                  options={defaultShirtStyleOptions}
+                  instanceId={shirtStyleId}
+                />
+              )}
+            />
+            <Error {...errors.country} />
+          </FormFieldSection>
+
+          <FormFieldSection>
+            <FormLabel>Preferencias Alimenticias</FormLabel>
+            <Controller
+              name="foodPreference"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  isClearable
+                  placeholder="Preferencias alimenticias"
+                  styles={customStyles}
+                  options={foodPreferenceOptions}
+                  instanceId={foodPreferenceId}
+                />
+              )}
+            />
+            <Error {...errors.country} />
+          </FormFieldSection>
+
+          <FormFieldSection>
+            <FormLabel>Alergias alimenticias</FormLabel>
+            <Controller
+              name="foodAllergy"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  isClearable
+                  placeholder="Alergias alimenticias"
+                  styles={customStyles}
+                  options={foodAllergyOptions}
+                  instanceId={shirtStyleId}
+                />
+              )}
+            />
+            <Error {...errors.country} />
+          </FormFieldSection>
+
+          <FormFieldSection>
+            <FormLabel>Pronombres</FormLabel>
+            <Controller
+              name="pronouns"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  isClearable
+                  placeholder="Pronombres"
+                  styles={customStyles}
+                  options={pronounsOptions}
+                  instanceId={pronounsSelectId}
+                />
+              )}
+            />
+            <Error {...errors.country} />
+          </FormFieldSection>
+        </FormFieldsSection>
+        <FormFieldsSection>
+          <UpdateButton
+            type="submit"
+            disabled={Object.entries(errors).length > 0 || !isDirty}
+          >
+            Actualizar
+          </UpdateButton>
+        </FormFieldsSection>
+      </FormSection>
+
       <Error
         message={submitMessage}
         color={submitMessage.includes("Error") ? "red" : "white"}
@@ -398,6 +793,6 @@ export const UserInformationForm = () => {
       {formErrors.map((error) => {
         return <Error key={error} message={error} color={"red"} />;
       })}
-    </form>
+    </Form>
   );
 };

--- a/src/helpers/API/index.ts
+++ b/src/helpers/API/index.ts
@@ -84,7 +84,7 @@ export const publicTicket = async (ticketId: string): Promise<PublicTicket> => {
 export const updateMe = async (
   object: Partial<UserPayload>
 ): Promise<UserType> => {
-  return await customFetch(`${API_URL}/users/`, {
+  return await customFetch(`${API_URL}/users/me`, {
     method: "PUT",
     body: JSON.stringify(object),
   });

--- a/src/helpers/API/types.ts
+++ b/src/helpers/API/types.ts
@@ -15,6 +15,11 @@ export type UserType = {
   seniority: null | string;
   username: null | string;
   yearsOfExperience: null | number;
+  foodPreference: null | string;
+  shirtSize: null | string;
+  shirtStyle: null | string;
+  foodAllergy: null | string;
+  pronouns: null | string;
 };
 
 export interface UserPayload {
@@ -26,6 +31,11 @@ export interface UserPayload {
   yearsOfExperience: number;
   country: string;
   gender: string;
+  foodPreference: string;
+  shirtSize: string;
+  shirtStyle: string;
+  foodAllergy: string;
+  pronouns: string;
 }
 
 export interface VolunteerPayload {


### PR DESCRIPTION
## Relacionado a este PR: https://github.com/JSConfCL/tickets-api/pull/56

### Closes https://github.com/JSConfCL/2022/issues/139
### Infinitamente más facil revisarlo sin `white-spaces` https://github.com/JSConfCL/2022/pull/157/files?w=1

------

Este PR actualiza el formulario de datos personales, para poder cambiar también las preferencias personales :) 

Agrega tb algunas cosillas en plan usabilidad y accesibilidad al form.
- Labels (Cuando tu formulario está lleno...no sabes que es cada field 😆)
- Coordina los espaciados de los form-fields
- Coordina los espaciados de form-sections
- No renderiza los errores por defecto (Y agrega una animación para cuando aparecen)
- Poquito de estilos a los placeholders para q se diferencien de los labels

# Imagen
![image](https://user-images.githubusercontent.com/952992/208375768-4b1e8f1e-6d23-4605-a512-d7417259892b.png)

# Su video
https://user-images.githubusercontent.com/952992/208376801-4c985230-aab4-4fde-88e4-7716c8c93126.mp4

