### PR TITLE
fix: food allergy option value

### DIFF
--- a/src/Components/UserPreferencesForm/index.tsx
+++ b/src/Components/UserPreferencesForm/index.tsx
@@ -80,7 +80,7 @@ const useGetFoodAllergyOptions = (foodAllergy?: string | null) => {
         label: "Crustaceos",
       },
       {
-        value: "nueces",
+        value: "ninguna",
         label: "Ninguna",
       },
     ];


### PR DESCRIPTION
Page: /settings
Section: Preferences
Field: Food allergy

<img width="682" alt="image" src="https://user-images.githubusercontent.com/68353701/209453031-53c36da4-48da-4b0b-b341-26a5692d3d06.png">

When you select 'Ninguna' option and save the changes. Option that is saved is ''Nueces (Maní, Almendras, etc)" because 'Ninguna' option has 'nueces' value