### PR TITLE
fix(Theme): fix chevron color

### DIFF
--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -116,7 +116,7 @@ const theme: Theme = {
       imageBorderColor: colors.jsconfBlack,
       shadowColor: colors.jsconfBlack,
       textColor: colors.white,
-      chevronColor: colors.jsconfBlack,
+      chevronColor: colors.white,
     },
     global: {
       backgroundColor: colors.black,
@@ -139,6 +139,10 @@ export const landingTheme: Theme = {
     navBar: {
       ...theme.elements.navBar,
       textColor: colors.jsconfBlack,
+    },
+    navBarDropDown: {
+      ...theme.elements.navBarDropDown,
+      chevronColor: colors.jsconfBlack,
     },
   },
 };


### PR DESCRIPTION
## Summary
- Change the color for the Navbar dropdown chevron

## Screenshots
### Before
![lego_dropdown_landing_before](https://user-images.githubusercontent.com/238259/209576725-0a0b02c3-fc55-43dd-a7e3-4d0da5372863.png)
![lego_dropdown_conf_before](https://user-images.githubusercontent.com/238259/209576726-f6387794-cce9-43a9-b449-fbf7d72ba7f5.png)

### After
![lego_dropdown_landing_after](https://user-images.githubusercontent.com/238259/209576753-ef80a475-8f6c-46a5-898f-43df74e98450.png)
![lego_dropdown_conf_after](https://user-images.githubusercontent.com/238259/209576752-991f14d7-9192-409f-ac3a-8547caa43227.png)
