### PR TITLE
197/link tree

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -25084,6 +25084,31 @@
         "description": "[See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock)",
         "fields": [
           {
+            "name": "bgColor",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "contentfulMetadata",
             "description": null,
             "args": [],
@@ -25093,6 +25118,60 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ContentfulMetadata",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SponsorBlockDescription",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "effectColors",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -25266,6 +25345,31 @@
             "deprecationReason": null
           },
           {
+            "name": "navColor",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "slug",
             "description": null,
             "args": [
@@ -25302,6 +25406,31 @@
                 "name": "Sys",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -25423,6 +25552,214 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "SponsorBlockDescription",
+        "description": null,
+        "fields": [
+          {
+            "name": "json",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "links",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SponsorBlockDescriptionLinks",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SponsorBlockDescriptionAssets",
+        "description": null,
+        "fields": [
+          {
+            "name": "block",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Asset",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hyperlink",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Asset",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SponsorBlockDescriptionEntries",
+        "description": null,
+        "fields": [
+          {
+            "name": "block",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hyperlink",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "inline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SponsorBlockDescriptionLinks",
+        "description": null,
+        "fields": [
+          {
+            "name": "assets",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SponsorBlockDescriptionAssets",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entries",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SponsorBlockDescriptionEntries",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "SponsorBlockFilter",
         "description": null,
@@ -25461,11 +25798,199 @@
             "deprecationReason": null
           },
           {
+            "name": "bgColor",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bgColor_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bgColor_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bgColor_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bgColor_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bgColor_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bgColor_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "contentfulMetadata",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ContentfulMetadataFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "effectColors_contains_all",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "effectColors_contains_none",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "effectColors_contains_some",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "effectColors_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -25853,6 +26378,98 @@
             "deprecationReason": null
           },
           {
+            "name": "navColor",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navColor_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navColor_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navColor_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navColor_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navColor_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navColor_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "slug",
             "description": null,
             "type": {
@@ -25951,6 +26568,98 @@
               "kind": "INPUT_OBJECT",
               "name": "SysFilter",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -26139,6 +26848,18 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "bgColor_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bgColor_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "externalLink_ASC",
             "description": null,
             "isDeprecated": false,
@@ -26182,6 +26903,18 @@
           },
           {
             "name": "name_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navColor_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navColor_DESC",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -26242,6 +26975,18 @@
           },
           {
             "name": "sys_publishedVersion_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "textColor_DESC",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -29480,6 +30225,60 @@
             "deprecationReason": null
           },
           {
+            "name": "testColors",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors2",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "title",
             "description": null,
             "args": [
@@ -30030,6 +30829,158 @@
             "deprecationReason": null
           },
           {
+            "name": "testColors",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors2_contains_all",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors2_contains_none",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors2_contains_some",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors2_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "title",
             "description": null,
             "type": {
@@ -30262,6 +31213,18 @@
           },
           {
             "name": "sys_publishedVersion_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "testColors_DESC",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/pages/link-tree.tsx
+++ b/pages/link-tree.tsx
@@ -1,0 +1,177 @@
+import styled from "@emotion/styled";
+import type { NextPage } from "next";
+import { useEffect } from "react";
+
+import Seo from "../src/Components/Seo";
+import JSConfLogo from "../src/Components/svgs/logo";
+import {
+  LinkTreeDocument,
+  LinkTreeQuery,
+} from "../src/graphql/link-tree.generated";
+import { urlQlient } from "../src/graphql/urql";
+import { ParseQuery } from "../src/helpers/types";
+import { ViewportSizes } from "../styles/theme";
+
+type Page = ParseQuery<LinkTreeQuery["page"]>;
+export interface PageProps {
+  seo: Page["seo"];
+  heroData: Page["heroBlock"];
+  links: Page["navBar"]["linksCollection"]["items"];
+  redirects: Page["navBar"]["buttonsCollection"]["items"];
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  scroll-behavior: smooth;
+  width: 100%;
+`;
+
+const Hero = styled.section`
+  font-size: 42px;
+  width: 90vw;
+  max-width: 600px;
+  margin: 0 auto;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: 200px;
+  position: relative;
+`;
+
+const StyledJSConfLogoWrapper = styled.a`
+  height: 100%;
+  height: 60px;
+  width: 60px;
+  aspect-ratio: 1/1;
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.jsconfYellow};
+  margin: 32px 0;
+
+  svg {
+    height: 60px;
+    width: 60px;
+  }
+
+  @media (min-width: ${ViewportSizes.Phone}px) {
+    margin: 48px 0;
+    height: 100px;
+    width: 100px;
+
+    svg {
+      height: 100px;
+      width: 100px;
+    }
+  }
+`;
+
+const StyledTitle = styled.h1(({ theme }) => ({
+  fontStyle: "normal",
+  fontWeight: 400,
+  fontSize: "90px",
+  letterSpacing: "1px",
+  lineHeight: "1em",
+  margin: 0,
+  wordSpacing: "100vw",
+  textAlign: "center",
+  marginBottom: "16px",
+  [theme.breakpoints.phoneOnly]: {
+    fontSize: "clamp(40.61px, 11vw, 90px)",
+  },
+}));
+
+const A = styled.a`
+  display: inline-block;
+  text-align: center;
+  border: 2px solid ${({ theme }) => theme.colors.jsconfYellow};
+  border-radius: 4px;
+  width: 100%;
+  font-size: 16px;
+  padding: 8px;
+  margin-bottom: 16px;
+
+  @media (min-width: ${ViewportSizes.Phone}px) {
+    padding: 16px;
+    font-size: 20px;
+  }
+`;
+
+const StyledSpan = styled.span`
+  display: inline-block;
+  margin-bottom: 16px;
+  text-align: center;
+
+  font-size: 16px;
+  padding: 8px;
+  margin-bottom: 8px;
+
+  @media (min-width: ${ViewportSizes.Phone}px) {
+    font-size: 20px;
+  }
+`;
+
+const Home: NextPage<PageProps> = ({
+  seo,
+  heroData,
+  links,
+  redirects,
+}: PageProps) => {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const hash = window.location.hash.slice(1);
+      const redirect = redirects.find((link) => link.contenido === hash);
+
+      if (redirect) {
+        window.location.assign(redirect.link);
+      }
+    }
+  }, [redirects]);
+  return (
+    <Container>
+      <Seo {...seo} />
+      <Hero>
+        <StyledJSConfLogoWrapper>
+          <JSConfLogo />
+        </StyledJSConfLogoWrapper>
+        <StyledTitle>{heroData.tile}</StyledTitle>
+        {heroData.firstSubtitle ? (
+          <StyledSpan>{heroData.firstSubtitle}</StyledSpan>
+        ) : null}
+        {heroData.secondSubtitle ? (
+          <StyledSpan>{heroData.secondSubtitle}</StyledSpan>
+        ) : null}
+        <br />
+        {links.map((link) => (
+          <A key={link.link} href={link.link}>
+            {link.contenido}
+          </A>
+        ))}
+      </Hero>
+    </Container>
+  );
+};
+
+export async function getStaticProps() {
+  const queryResults = await urlQlient
+    .query(LinkTreeDocument, {
+      id: "2wAn9UxGwc1bgUTOOT4SPW",
+      locale: "es-CL",
+      isPreview: Boolean(process.env.NEXT_PUBLIC_CONTENTFUL_IS_PREVIEW),
+    })
+    .toPromise();
+  const page = queryResults.data?.page as Page;
+
+  const props = {
+    seo: page?.seo || null,
+    heroData: page?.heroBlock || null,
+    links: page?.navBar.linksCollection.items || [],
+    redirects: page?.navBar.buttonsCollection.items || [],
+  };
+
+  return {
+    props,
+  };
+}
+
+export default Home;

--- a/src/graphql/link-tree.generated.tsx
+++ b/src/graphql/link-tree.generated.tsx
@@ -1,0 +1,100 @@
+import gql from "graphql-tag";
+import * as Urql from "urql";
+
+import * as Types from "../types";
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type LinkTreeQueryVariables = Types.Exact<{
+  locale: Types.Scalars["String"];
+  isPreview?: Types.InputMaybe<Types.Scalars["Boolean"]>;
+}>;
+
+export type LinkTreeQuery = {
+  __typename?: "Query";
+  page?: {
+    __typename?: "Page";
+    seo?: {
+      __typename?: "Seo";
+      title?: string | null;
+      description?: string | null;
+      metadata?: any | null;
+    } | null;
+    heroBlock?: {
+      __typename?: "HeroBlock";
+      tile?: string | null;
+      firstSubtitle?: string | null;
+      secondSubtitle?: string | null;
+    } | null;
+    navBar?: {
+      __typename?: "NavigationBar";
+      description?: {
+        __typename?: "NavigationBarDescription";
+        json: any;
+      } | null;
+      linksCollection?: {
+        __typename?: "NavigationBarLinksCollection";
+        items: Array<{
+          __typename?: "LinkItem";
+          contenido?: string | null;
+          link?: string | null;
+          isBlank?: boolean | null;
+          sys: { __typename?: "Sys"; id: string };
+        } | null>;
+      } | null;
+      buttonsCollection?: {
+        __typename?: "NavigationBarButtonsCollection";
+        items: Array<{
+          __typename?: "LinkItem";
+          contenido?: string | null;
+          link?: string | null;
+        } | null>;
+      } | null;
+    } | null;
+  } | null;
+};
+
+export const LinkTreeDocument = gql`
+  query LinkTree($locale: String!, $isPreview: Boolean = false) {
+    page(id: "3yNee3jJ5xkHkCPyszAiOp", locale: $locale, preview: $isPreview) {
+      seo {
+        title
+        description
+        metadata
+      }
+      heroBlock {
+        tile
+        firstSubtitle
+        secondSubtitle
+      }
+      navBar {
+        description {
+          json
+        }
+        linksCollection(limit: 20) {
+          items {
+            sys {
+              id
+            }
+            contenido
+            link
+            isBlank
+          }
+        }
+        buttonsCollection(limit: 20) {
+          items {
+            contenido
+            link
+          }
+        }
+      }
+    }
+  }
+`;
+
+export function useLinkTreeQuery(
+  options: Omit<Urql.UseQueryArgs<LinkTreeQueryVariables>, "query">
+) {
+  return Urql.useQuery<LinkTreeQuery, LinkTreeQueryVariables>({
+    query: LinkTreeDocument,
+    ...options,
+  });
+}

--- a/src/graphql/link-tree.graphql
+++ b/src/graphql/link-tree.graphql
@@ -1,0 +1,35 @@
+query LinkTree($locale: String!, $isPreview: Boolean = false) {
+  page(id: "3yNee3jJ5xkHkCPyszAiOp", locale: $locale, preview: $isPreview) {
+    seo {
+      title
+      description
+      metadata
+    }
+    heroBlock {
+      tile
+      firstSubtitle
+      secondSubtitle
+    }
+    navBar {
+      description {
+        json
+      }
+      linksCollection(limit: 20) {
+        items {
+          sys {
+            id
+          }
+          contenido
+          link
+          isBlank
+        }
+      }
+      buttonsCollection(limit: 20) {
+        items {
+          contenido
+          link
+        }
+      }
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3284,16 +3284,36 @@ export type SponsorTypeArgs = {
 /** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock) */
 export type SponsorBlock = Entry & {
   __typename?: "SponsorBlock";
+  bgColor?: Maybe<Scalars["String"]>;
   contentfulMetadata: ContentfulMetadata;
+  description?: Maybe<SponsorBlockDescription>;
+  effectColors?: Maybe<Array<Maybe<Scalars["String"]>>>;
   externalLink?: Maybe<Scalars["String"]>;
   image?: Maybe<Asset>;
   imageParamsDesktop?: Maybe<Scalars["String"]>;
   imageParamsMobile?: Maybe<Scalars["String"]>;
   linkedFrom?: Maybe<SponsorBlockLinkingCollections>;
   name?: Maybe<Scalars["String"]>;
+  navColor?: Maybe<Scalars["String"]>;
   slug?: Maybe<Scalars["String"]>;
   sys: Sys;
+  textColor?: Maybe<Scalars["String"]>;
   title?: Maybe<SponsorBlockTitle>;
+};
+
+/** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock) */
+export type SponsorBlockBgColorArgs = {
+  locale?: InputMaybe<Scalars["String"]>;
+};
+
+/** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock) */
+export type SponsorBlockDescriptionArgs = {
+  locale?: InputMaybe<Scalars["String"]>;
+};
+
+/** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock) */
+export type SponsorBlockEffectColorsArgs = {
+  locale?: InputMaybe<Scalars["String"]>;
 };
 
 /** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock) */
@@ -3328,7 +3348,17 @@ export type SponsorBlockNameArgs = {
 };
 
 /** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock) */
+export type SponsorBlockNavColorArgs = {
+  locale?: InputMaybe<Scalars["String"]>;
+};
+
+/** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock) */
 export type SponsorBlockSlugArgs = {
+  locale?: InputMaybe<Scalars["String"]>;
+};
+
+/** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/sponsorBlock) */
+export type SponsorBlockTextColorArgs = {
   locale?: InputMaybe<Scalars["String"]>;
 };
 
@@ -3345,10 +3375,49 @@ export type SponsorBlockCollection = {
   total: Scalars["Int"];
 };
 
+export type SponsorBlockDescription = {
+  __typename?: "SponsorBlockDescription";
+  json: Scalars["JSON"];
+  links: SponsorBlockDescriptionLinks;
+};
+
+export type SponsorBlockDescriptionAssets = {
+  __typename?: "SponsorBlockDescriptionAssets";
+  block: Array<Maybe<Asset>>;
+  hyperlink: Array<Maybe<Asset>>;
+};
+
+export type SponsorBlockDescriptionEntries = {
+  __typename?: "SponsorBlockDescriptionEntries";
+  block: Array<Maybe<Entry>>;
+  hyperlink: Array<Maybe<Entry>>;
+  inline: Array<Maybe<Entry>>;
+};
+
+export type SponsorBlockDescriptionLinks = {
+  __typename?: "SponsorBlockDescriptionLinks";
+  assets: SponsorBlockDescriptionAssets;
+  entries: SponsorBlockDescriptionEntries;
+};
+
 export type SponsorBlockFilter = {
   AND?: InputMaybe<Array<InputMaybe<SponsorBlockFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<SponsorBlockFilter>>>;
+  bgColor?: InputMaybe<Scalars["String"]>;
+  bgColor_contains?: InputMaybe<Scalars["String"]>;
+  bgColor_exists?: InputMaybe<Scalars["Boolean"]>;
+  bgColor_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  bgColor_not?: InputMaybe<Scalars["String"]>;
+  bgColor_not_contains?: InputMaybe<Scalars["String"]>;
+  bgColor_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  description_contains?: InputMaybe<Scalars["String"]>;
+  description_exists?: InputMaybe<Scalars["Boolean"]>;
+  description_not_contains?: InputMaybe<Scalars["String"]>;
+  effectColors_contains_all?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  effectColors_contains_none?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  effectColors_contains_some?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  effectColors_exists?: InputMaybe<Scalars["Boolean"]>;
   externalLink?: InputMaybe<Scalars["String"]>;
   externalLink_contains?: InputMaybe<Scalars["String"]>;
   externalLink_exists?: InputMaybe<Scalars["Boolean"]>;
@@ -3378,6 +3447,13 @@ export type SponsorBlockFilter = {
   name_not?: InputMaybe<Scalars["String"]>;
   name_not_contains?: InputMaybe<Scalars["String"]>;
   name_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  navColor?: InputMaybe<Scalars["String"]>;
+  navColor_contains?: InputMaybe<Scalars["String"]>;
+  navColor_exists?: InputMaybe<Scalars["Boolean"]>;
+  navColor_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  navColor_not?: InputMaybe<Scalars["String"]>;
+  navColor_not_contains?: InputMaybe<Scalars["String"]>;
+  navColor_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   slug?: InputMaybe<Scalars["String"]>;
   slug_contains?: InputMaybe<Scalars["String"]>;
   slug_exists?: InputMaybe<Scalars["Boolean"]>;
@@ -3386,6 +3462,13 @@ export type SponsorBlockFilter = {
   slug_not_contains?: InputMaybe<Scalars["String"]>;
   slug_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   sys?: InputMaybe<SysFilter>;
+  textColor?: InputMaybe<Scalars["String"]>;
+  textColor_contains?: InputMaybe<Scalars["String"]>;
+  textColor_exists?: InputMaybe<Scalars["Boolean"]>;
+  textColor_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  textColor_not?: InputMaybe<Scalars["String"]>;
+  textColor_not_contains?: InputMaybe<Scalars["String"]>;
+  textColor_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   title_contains?: InputMaybe<Scalars["String"]>;
   title_exists?: InputMaybe<Scalars["Boolean"]>;
   title_not_contains?: InputMaybe<Scalars["String"]>;
@@ -3412,6 +3495,8 @@ export type SponsorBlockLinkingCollectionsSponsorTypeCollectionArgs = {
 };
 
 export enum SponsorBlockOrder {
+  BgColorAsc = "bgColor_ASC",
+  BgColorDesc = "bgColor_DESC",
   ExternalLinkAsc = "externalLink_ASC",
   ExternalLinkDesc = "externalLink_DESC",
   ImageParamsDesktopAsc = "imageParamsDesktop_ASC",
@@ -3420,6 +3505,8 @@ export enum SponsorBlockOrder {
   ImageParamsMobileDesc = "imageParamsMobile_DESC",
   NameAsc = "name_ASC",
   NameDesc = "name_DESC",
+  NavColorAsc = "navColor_ASC",
+  NavColorDesc = "navColor_DESC",
   SlugAsc = "slug_ASC",
   SlugDesc = "slug_DESC",
   SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
@@ -3430,6 +3517,8 @@ export enum SponsorBlockOrder {
   SysPublishedAtDesc = "sys_publishedAt_DESC",
   SysPublishedVersionAsc = "sys_publishedVersion_ASC",
   SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TextColorAsc = "textColor_ASC",
+  TextColorDesc = "textColor_DESC",
 }
 
 export type SponsorBlockTitle = {
@@ -3807,6 +3896,8 @@ export type Talk = Entry & {
   linkedFrom?: Maybe<TalkLinkingCollections>;
   speaker?: Maybe<Entry>;
   sys: Sys;
+  testColors?: Maybe<Scalars["String"]>;
+  testColors2?: Maybe<Array<Maybe<Scalars["String"]>>>;
   title?: Maybe<Scalars["String"]>;
 };
 
@@ -3829,6 +3920,16 @@ export type TalkLinkedFromArgs = {
 export type TalkSpeakerArgs = {
   locale?: InputMaybe<Scalars["String"]>;
   preview?: InputMaybe<Scalars["Boolean"]>;
+};
+
+/** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/talk) */
+export type TalkTestColorsArgs = {
+  locale?: InputMaybe<Scalars["String"]>;
+};
+
+/** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/talk) */
+export type TalkTestColors2Args = {
+  locale?: InputMaybe<Scalars["String"]>;
 };
 
 /** [See type definition](https://app.contentful.com/spaces/1kfhsqlc8ewi/content_types/talk) */
@@ -3887,6 +3988,17 @@ export type TalkFilter = {
   duration_not_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
   speaker_exists?: InputMaybe<Scalars["Boolean"]>;
   sys?: InputMaybe<SysFilter>;
+  testColors?: InputMaybe<Scalars["String"]>;
+  testColors2_contains_all?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  testColors2_contains_none?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  testColors2_contains_some?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  testColors2_exists?: InputMaybe<Scalars["Boolean"]>;
+  testColors_contains?: InputMaybe<Scalars["String"]>;
+  testColors_exists?: InputMaybe<Scalars["Boolean"]>;
+  testColors_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  testColors_not?: InputMaybe<Scalars["String"]>;
+  testColors_not_contains?: InputMaybe<Scalars["String"]>;
+  testColors_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   title?: InputMaybe<Scalars["String"]>;
   title_contains?: InputMaybe<Scalars["String"]>;
   title_exists?: InputMaybe<Scalars["Boolean"]>;
@@ -3919,6 +4031,8 @@ export enum TalkOrder {
   SysPublishedAtDesc = "sys_publishedAt_DESC",
   SysPublishedVersionAsc = "sys_publishedVersion_ASC",
   SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TestColorsAsc = "testColors_ASC",
+  TestColorsDesc = "testColors_DESC",
   TitleAsc = "title_ASC",
   TitleDesc = "title_DESC",
 }


### PR DESCRIPTION
## Summary
- Define a custom link-tree for the conference
- Extra: Hacky redirect, buttons on navbar are redirects where content is the `#anchor-id`. e.g: http://localhost:3001/link-tree#LightningTalks
 
## Media
### Screenshots
![197_desktop](https://user-images.githubusercontent.com/238259/213593161-49feab8b-959f-4855-8cdb-4f2c5b2bbaf0.png)
![197_mobile](https://user-images.githubusercontent.com/238259/213593167-d0a38e8a-898e-4af8-b1ff-1455c0c7a81c.png)

## Closes
Closes #197 